### PR TITLE
SNOW-203610 Add logging for exec failure

### DIFF
--- a/snowflake/version.sh
+++ b/snowflake/version.sh
@@ -1,2 +1,2 @@
 #0.9.62 is the firejail version, last suffix is snowflake identifier
-FIREJAIL_SF_VERSION=0.9.62.3
+FIREJAIL_SF_VERSION=0.9.62.4

--- a/src/firejail/sandbox.c
+++ b/src/firejail/sandbox.c
@@ -547,10 +547,13 @@ void start_application(int no_sandbox, FILE *fp) {
 #ifdef HAVE_SECCOMP
 		seccomp_install_filters();
 #endif
-		if (rv)
+		if (rv) {
 			execvp(cfg.original_argv[cfg.original_program_index], &cfg.original_argv[cfg.original_program_index]);
-		else
+			fprintf(stderr, "Error: exec failed: %s\n", strerror(errno));
+		}
+		else {
 			fprintf(stderr, "Error: no suitable %s executable found\n", cfg.original_argv[cfg.original_program_index]);
+		}
 		exit(1);
 	}
 	//****************************************


### PR DESCRIPTION
Firejail already does some basic checks to ensure that the child process looks launch-able, but there is a race between that check and the actual exec.  This change writes strerror(errno) to stderr in the case that exec does fail.

This was tested by (temporarily) commenting out the existing checks that verify that the provide child is indeed a valid executable and then trying to launch something that wasn't runable.  